### PR TITLE
Handle apostrophes and commas in exclusion reasons

### DIFF
--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -240,7 +240,7 @@ PRISMA_flowdiagram <- function( #nolint
         paste(
           paste(
             "\n",
-            other_excluded[, 1],
+            PRISMA_escape_text_(other_excluded[, 1]),
             " (n = ", other_excluded[, 2], ")",
             sep = ""
           ),
@@ -375,7 +375,7 @@ PRISMA_flowdiagram <- function( #nolint
       paste(
         paste(
           "\n",
-          dbr_excluded[, 1],
+          PRISMA_escape_text_(dbr_excluded[, 1]),
           " (n = ", dbr_excluded[, 2], ")",
         sep = ""
         ),
@@ -1447,7 +1447,7 @@ PRISMA_data <- function(data) { #nolint
   )
   dbr_excluded <- data.frame(
     reason = gsub(
-      ",.*$",
+      ",\\s*\\d+\\s*$",
       "",
       unlist(
         strsplit(
@@ -1464,8 +1464,8 @@ PRISMA_data <- function(data) { #nolint
       )
     ),
     n = gsub(
-      ".*,",
-      "",
+      "^.*,\\s*(\\d+)\\s*$",
+      "\\1",
       unlist(
         strsplit(
           as.character(
@@ -1493,7 +1493,7 @@ PRISMA_data <- function(data) { #nolint
   )
   other_excluded <- data.frame(
     reason = gsub(
-      ",.*$",
+      ",\\s*\\d+\\s*$",
       "",
       unlist(
         strsplit(
@@ -1510,8 +1510,8 @@ PRISMA_data <- function(data) { #nolint
       )
     ),
     n = gsub(
-      ".*,",
-      "",
+      "^.*,\\s*(\\d+)\\s*$",
+      "\\1",
       unlist(
         strsplit(
           as.character(

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,17 @@
 # Utility functions for PRISMA_flowdiagram
 
+#' Escape special characters for DOT syntax
+#' @keywords internal
+PRISMA_escape_text_ <- function(text) { #nolint
+  if (is.null(text)) return(text)
+  text <- as.character(text)
+  # Escape backslashes first, then quotes and apostrophes
+  text <- gsub("\\", "\\\\", text, fixed = TRUE)
+  text <- gsub('"', '\\"', text, fixed = TRUE)
+  text <- gsub("'", "\\'", text, fixed = TRUE)
+  return(text)
+}
+
 #' Calculate the correct height of a box from a list (e.g. of exclusion reasons)
 #' @description Get the correct height for a box
 #' @param n the number of rows of text in the label


### PR DESCRIPTION
# Fix apostrophes and commas in exclusion reasons

## Problem
Users encountered two issues when entering exclusion reasons:

1. **Syntax Error 140** when exclusion reasons contained apostrophes (e.g., "doesn't", "isn't", "won't")
2. **Text truncation** when exclusion reasons contained commas - only text before the first comma was displayed

## Root Cause
1. **Apostrophes/quotes**: DiagrammeR's DOT syntax parser failed when unescaped special characters were inserted directly into the graph definition
2. **Commas**: The parsing logic used naive regex (`",.*$"` and `".*,"`) that split on the first/last comma, truncating exclusion reasons that legitimately contained commas

## Solution

### 1. Added text escaping for DOT syntax
- Created `PRISMA_escape_text_()` utility function in `utils.R`
- Escapes backslashes, quotes, and apostrophes before inserting into DiagrammeR graph
- Applied to both `dbr_excluded[, 1]` and `other_excluded[, 1]` text

### 2. Fixed exclusion reason parsing logic
- Changed from naive comma splitting to pattern-based parsing
- **Before**: `gsub(",.*$", "", text)` - removed everything after first comma
- **After**: `gsub(",\\s*\\d+\\s*$", "", text)` - removes only final comma + number
- **Before**: `gsub(".*,", "", text)` - removed everything before last comma  
- **After**: `gsub("^.*,\\s*(\\d+)\\s*$", "\\1", text)` - extracts only final number
